### PR TITLE
Add source demo session to com5003-/mt310s2-meas-session

### DIFF
--- a/target/com5003-meas-session.json
+++ b/target/com5003-meas-session.json
@@ -96,6 +96,11 @@
         "id": 1190
       },
       {
+        "name" : "sourcemodule",
+        "configFile" : "demo-sourcemodule.xml",
+        "id": 1300
+      },
+      {
         "name" : "scpimodule",
         "configFile" : "com5003-scpimodule.xml",
         "id": 9999

--- a/target/mt310s2-meas-session.json
+++ b/target/mt310s2-meas-session.json
@@ -116,6 +116,11 @@
         "id": 1210
       },
       {
+        "name" : "sourcemodule",
+        "configFile" : "demo-sourcemodule.xml",
+        "id": 1300
+      },
+      {
         "name" : "scpimodule",
         "configFile" : "mt310s2-scpimodule.xml",
         "id": 9999


### PR DESCRIPTION
* We want to see the GUI on the device to make sure our layout assumptions
  are valid
* As long as debug sources are not added by running debugger, nothing changes

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>