### PR TITLE
demo-session: Add scpi module

### DIFF
--- a/target/demo-session.json
+++ b/target/demo-session.json
@@ -14,6 +14,11 @@
         "name" : "sourcemodule",
         "configFile" : "demo-sourcemodule.xml",
         "id": 1300
+      },
+      {
+        "name" : "scpimodule",
+        "configFile" : "demo-scpimodule.xml",
+        "id": 9999
       }
     ]
 }


### PR DESCRIPTION
* SCPI module connects to serial USB automatically. To see what we can do to
  avoid conflicts with sourcemodule add it to our demo-session
* We need SCPI module once we start with SCPI support for sources - let's call
 it the json-parameter challenge :)
* For not much was tested except that it does not crash although configured to
  use components not available in demo-session

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>