### PR TITLE
mt310s2-emob-session: Add fftmodule for signed actual values of I/U

### DIFF
--- a/sessions/mt310s2-emob-session.json
+++ b/sessions/mt310s2-emob-session.json
@@ -31,6 +31,11 @@
         "id": 1050
       },
       {
+        "name" : "fftmodule",
+        "configFile" : "mt310s2-fftmodule.xml",
+        "id": 1060
+      },
+      {
         "name" : "power1module",
         "configFile" : "mt310s2-power1module-4WA-only.xml",
         "id": 1070


### PR DESCRIPTION
Surprise: In GUI we use RMS values for actual values: These are always
positive!

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>